### PR TITLE
made output path neutral, so it's not specific to any machine, and th…

### DIFF
--- a/go-hid-card-reader/config.json
+++ b/go-hid-card-reader/config.json
@@ -1,3 +1,3 @@
 {
-  "datafileloc" : "/Users/kirk/OneDrive/gocode/tmp/test.json"
+  "datafileloc" : "work_log_001.json"
 }

--- a/go-hid-card-reader/main.go
+++ b/go-hid-card-reader/main.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"net/http"
 	"os"
+	"time"
 )
 
 type Config struct {
@@ -18,8 +19,7 @@ type WorkRecord struct { //define the structure for the work hour.
 	WorkTypeOther    string
 	HoursWorked      string
 	PictureLoc       string
-	/* I need to figure out how to convert date time for json. this is a little more involved.
-	DTS              time.Time */
+	DateOfWork       string
 }
 
 func LoadConfiguration(filename string) (Config, error) {
@@ -52,7 +52,7 @@ func addhours(w http.ResponseWriter, r *http.Request) {
 	wr.MemberCardNumber = r.FormValue("membercardnumber")
 	wr.WorkType = r.FormValue("worktype")
 	wr.HoursWorked = r.FormValue("hoursworked")
-
+	wr.DateOfWork = time.Now().Format(time.RFC850)
 	b, err := json.Marshal(wr)
 	if err != nil {
 		http.Error(w, err.Error(), 500)
@@ -61,6 +61,7 @@ func addhours(w http.ResponseWriter, r *http.Request) {
 
 	f.Write(b)
 	f.Close()
+	http.Redirect(w, r, "/", http.StatusFound)
 }
 
 func main() {


### PR DESCRIPTION
…us is

portable during dev.

added current date as human readable string.  This is effectively a
creation date for the record, but will likely suffice for logging work

following form submit and log entry, redirect back to input page